### PR TITLE
Add FastAPI-based customer microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# customer
+# Customer Microservice
+
+This repository contains a minimal FastAPI microservice that manages e-commerce customers. The service supports basic CRUD operations and keeps data in memory.
+
+## Endpoints
+
+- `GET /customers` - List all customers
+- `POST /customers` - Create a new customer
+- `GET /customers/{customer_id}` - Retrieve a customer by ID
+- `PUT /customers/{customer_id}` - Update an existing customer
+- `DELETE /customers/{customer_id}` - Delete a customer
+
+## Development
+
+Install dependencies (if not already installed) and run tests:
+
+```bash
+pip install fastapi uvicorn pytest
+pytest
+```
+
+To start the service locally:
+
+```bash
+uvicorn app.main:app --reload
+```
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,31 @@
+from fastapi import FastAPI, HTTPException
+from .models import Customer
+from .service import CustomerService
+
+app = FastAPI(title="Customer Service")
+service = CustomerService()
+
+@app.get("/customers", response_model=list[Customer])
+def list_customers():
+    return service.list_customers()
+
+@app.post("/customers", response_model=Customer)
+def create_customer(customer: Customer):
+    return service.create_customer(customer)
+
+@app.get("/customers/{customer_id}", response_model=Customer)
+def get_customer(customer_id: int):
+    try:
+        return service.get_customer(customer_id)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="Customer not found")
+
+@app.put("/customers/{customer_id}", response_model=Customer)
+def update_customer(customer_id: int, customer: Customer):
+    return service.update_customer(customer_id, customer)
+
+@app.delete("/customers/{customer_id}")
+def delete_customer(customer_id: int):
+    service.delete_customer(customer_id)
+    return {"status": "deleted"}
+

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class Customer(BaseModel):
+    id: int
+    name: str
+    email: str
+    address: Optional[str] = None
+

--- a/app/service.py
+++ b/app/service.py
@@ -1,0 +1,29 @@
+from typing import Dict, List
+from .models import Customer
+
+class CustomerService:
+    def __init__(self) -> None:
+        self.customers: Dict[int, Customer] = {}
+        self.next_id = 1
+
+    def list_customers(self) -> List[Customer]:
+        return list(self.customers.values())
+
+    def create_customer(self, customer: Customer) -> Customer:
+        customer.id = self.next_id
+        self.customers[self.next_id] = customer
+        self.next_id += 1
+        return customer
+
+    def get_customer(self, customer_id: int) -> Customer:
+        return self.customers[customer_id]
+
+    def update_customer(self, customer_id: int, customer: Customer) -> Customer:
+        customer.id = customer_id
+        self.customers[customer_id] = customer
+        return customer
+
+    def delete_customer(self, customer_id: int) -> None:
+        if customer_id in self.customers:
+            del self.customers[customer_id]
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_create_and_get_customer():
+    response = client.post('/customers', json={'id': 0, 'name': 'John', 'email': 'john@example.com'})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['id'] == 1
+    cust_id = data['id']
+
+    response = client.get(f'/customers/{cust_id}')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['name'] == 'John'
+    assert data['email'] == 'john@example.com'
+
+
+def test_list_customers():
+    client.post('/customers', json={'id': 0, 'name': 'Alice', 'email': 'alice@example.com'})
+    response = client.get('/customers')
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+def test_delete_customer():
+    response = client.post('/customers', json={'id': 0, 'name': 'Bob', 'email': 'bob@example.com'})
+    cust_id = response.json()['id']
+    response = client.delete(f'/customers/{cust_id}')
+    assert response.status_code == 200
+    response = client.get(f'/customers/{cust_id}')
+    assert response.status_code == 404
+


### PR DESCRIPTION
## Summary
- implement basic FastAPI CRUD service under `app/`
- include unit tests for API endpoints
- update README with usage and development instructions

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*